### PR TITLE
Add yosuke furukawa as benchmark WG member

### DIFF
--- a/benchmarking.md
+++ b/benchmarking.md
@@ -21,5 +21,6 @@ Initial proposed members include:
   + Yang Lei
   + Ali Sheikh
   + Chris Bailey
+  + Yosuke Furukawa
   + + reach out to contacts at Payal, Yahoo, Netflix who might be interested
   + + other interested parties from Node.js and io.js communities


### PR DESCRIPTION
I have high motivation to improve performance on Node.js

And I am fixing benchmark tests, If all tests are stable, We can measure performance continuously. And we can detect performance down on every release.
